### PR TITLE
Fix infinite loop when the buffer ends with \r #123

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -306,8 +306,8 @@ void HTTPConnection::readLine(int lengthLimit) {
       }
     } else {
       _parserLine.text += newChar;
-      _bufferProcessed += 1;
     }
+    _bufferProcessed += 1;
 
     // Check that the max request string size is not exceeded
     if (_parserLine.text.length() > lengthLimit) {

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -131,6 +131,8 @@ private:
   int _bufferProcessed;
   // The index on the receive_buffer that is the first one which is empty at the end.
   int _bufferUnusedIdx;
+  // If \r character has been read, in this case we expect \n to terminate the line
+  bool partialTerminationParsed = false;
 
   // Socket address, length etc for the connection
   struct sockaddr _sockAddr;


### PR DESCRIPTION
This is possible fix for infinite loop as mentioned in PR #123 of [esp32_https_server] (https://github.com/fhessel/esp32_https_server)